### PR TITLE
Removes not exposed importing

### DIFF
--- a/services/graphql-service/index.js
+++ b/services/graphql-service/index.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const graphqlHTTP = require('express-graphql');
 const { GraphQLSchema } = require('graphql');
-const { schema, QueryObjectType, MutationsType } = require('./schema/application.schema');
+const { QueryObjectType, MutationsType } = require('./schema/application.schema');
 const app = express();
 
 const rootValue = {


### PR DESCRIPTION
`schema` is not exported from ./schema/application.schema. So it could be removed.